### PR TITLE
Updates to add WIP status and remove Google links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
+**NOTE, May 25, 2021: This repo is work-in-progress as part of the Vulnerability Disclosure Working Group. Contents in this repo are not finalized recommendations.**
+
 # Guide to coordinated vulnerability disclosure for open source projects
 
 
-This repository is a set of resources and reference materials to help open source projects to coordinated vulnerability disclosure. It was originally designed to help open source projects coming out of Google, so not all materials or recommendations may be applicable to your project.
+This repository is a set of resources and reference materials to help open source projects to coordinated vulnerability disclosure.
 
-_For Googlers: Please see the OSPO site for documentation._
 
 ## This repository contains:
 


### PR DESCRIPTION
Adds a note that this is WIP as part of the Vuln Disclosure WG and removes Google specific links that are no longer relevant.