### PR TITLE
Removes Google references from GUIDE.md

### DIFF
--- a/guide.md
+++ b/guide.md
@@ -29,7 +29,7 @@ This guide is intended to help open source maintainers create and maintain a coo
 
 ### About this guide
 
-This guide was produced by the Google Open Source Programs Office security program, Google’s vulnerability response team, and Google’s infrastructure security team. It was written for Googlers working in open source projects, with the types of projects Google tends to open source and contribute to in mind. We shared this guide in hopes of helping all open source projects have good vulnerability management, but not all advice in this guide is applicable to all open source projects.
+This guide was produced by the Open Source Security Foundation Vulnerability Disclosure Working Group. The OpenSSF Vulnerability Disclosure Working Group believes coordinated vulnerabilty disclosure is the appropriate model for most open source projects, and the advice in this guide follows that model. Not all advice in this guide is applicable to all open source projects; projects may need to modify the recommendations and materials to fit their project.
 
 
 ### Who's a vulnerability reporter?
@@ -253,4 +253,4 @@ Maybe it’s found in a research paper, an article, or on social media, but if s
 
 ## Acknowledgements
 
-Thank you to the Google Open Source Programs Office, the Google vulnerability response team, the Google infrastructure security team, and Project Zero team for their work on this guide. Thank you to the wider security and open source communities whose work informed this guide, including the [OpenStack Vulnerability Management Process](https://security.openstack.org/vmt-process.html), [Project Zero’s disclosure process](https://googleprojectzero.blogspot.com/p/vulnerability-disclosure-faq.html), and the [Kubernetes security and disclosure process](https://kubernetes.io/docs/reference/issues-security/security/).
+Thank you to the wider security and open source communities whose work informed this guide, including the [Google Open Source Programs Office and Google security teams](https://github.com/google/oss-vulnerability-guide), the [OpenStack Vulnerability Management Process](https://security.openstack.org/vmt-process.html), [Project Zero’s disclosure process](https://googleprojectzero.blogspot.com/p/vulnerability-disclosure-faq.html), and the [Kubernetes security and disclosure process](https://kubernetes.io/docs/reference/issues-security/security/).


### PR DESCRIPTION
Removes references to Google's OSPO and security teams in opening and adds OSSF Vuln Disclosure WG, and moves Google OSPO and security teams to acknowledgments section.