### PR TITLE
Remove WIP header and add feedback to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-**NOTE, May 25, 2021: This repo is work-in-progress as part of the Vulnerability Disclosure Working Group. Contents in this repo are not finalized recommendations.**
-
 # Guide to coordinated vulnerability disclosure for open source software projects
 
 
@@ -17,3 +15,7 @@ This repository is a set of resources and reference materials to help open sourc
 If you are new to coordinated vulnerability disclosure, it is recommended you start with the [Guide](https://github.com/ossf/oss-vulnerability-guide/blob/main/guide.md). While it is dense, you will want to be familiar with this information and the concepts presented *before* you need to address a vulnerability report. 
 
 If you are familiar with coordinated vulnerability disclosure, you can get a refresher by skipping to the [Response Process](https://github.com/ossf/oss-vulnerability-guide/blob/main/guide.md#response-process) section of the Guide, or go straight to the [Runbook](https://github.com/ossf/oss-vulnerability-guide/blob/main/runbook.md).
+
+## Feedback
+
+We welcome feedback from OSS project maintainers and security researchers on this guide. Opening a [GitHub Issue](https://github.com/ossf/oss-vulnerability-guide/issues) is the best way to send feedback (see [CONTRIBUTING.md](https://github.com/ossf/oss-vulnerability-guide/blob/main/CONTRIBUTING.md) for directions on submitting PRs).


### PR DESCRIPTION
Removes WIP header from README and adds directions for maintainers and researchers to use GitHub Issues for feedback