### PR TITLE
Add suggestions around GitHub Security Advisories

### DIFF
--- a/guide.md
+++ b/guide.md
@@ -120,7 +120,7 @@ The vulnerability reporter is doing you a favor; don't add more steps than absol
 ##### If you are using GitHub
 
 You may choose to use GitHub Security Advisory, but it *cannot* today be used as a general-purpose intake method for vulnerability reports.
-GitHub Security Advisory is a GitHub feature that allows *only* selected users to privately share information about reported issues, develop patches on a private branch, and publish a security advisory.
+GitHub Security Advisory is a GitHub feature that allows *only* repository maintainers to privately share information about reported issues, develop patches on a private branch, and publish a security advisory.
 The GitHub Security Advisory workflow starts when a repo or org admin opens a Security Advisory.
 General users cannot create a Security Advisory or create a private "security issue" out of a standard GitHub issue.
 Thus, currently GitHub Security Advisory *must* be supplemented with other intake mechanisms.
@@ -180,7 +180,15 @@ Many issue trackers can separate security issues from regular issues. Whatever t
 
 ### Establish a CNA contact
 
-CNAs ([CVE Numbering Authorities](https://cve.mitre.org/cve/request_id.html)) are organizations that can assign CVE numbers to new vulnerabilities. CNAs have various scopes and do not issue CVEs outside of their scopes. (e.g., While the (fictitious) SpeakerCompany uses open source software in their products, their scope could be restricted to vulnerabilities only found in SpeakerCompany software, and they would not handle a CVE request for an upstream issue.) There are many CNAs; the only "pre-work" for the VMT is to know of at least one CNA whose scope covers your project and who you will go to first for a CVE assignment. MITRE, the organization that manages CVE administration, is also a ["CNA of Last Resort" for open source projects](https://cveform.mitre.org/) and can be used if no better scope is available.
+CNAs ([CVE Numbering Authorities](https://cve.mitre.org/cve/request_id.html)) are organizations that can assign CVE numbers to new vulnerabilities. CNAs have various scopes and do not issue CVEs outside of their scopes. (e.g., While the (fictitious) SpeakerCompany uses open source software in their products, their scope could be restricted to vulnerabilities only found in SpeakerCompany software, and they would not handle a CVE request for an upstream issue.)
+
+#### If you are using GitHub
+
+GitHub is a CNA for the open-source code that is published on GitHub. GitHub Security Advisories allow you to draft your disclosure, and submit it for approval and publishing. For more information see [Creating a security advisory: GitHub documentation](https://docs.github.com/en/code-security/security-advisories/creating-a-security-advisory).
+
+#### If you are using another service
+
+There are many CNAs; the only "pre-work" for the VMT is to know of at least one CNA whose scope covers your project and who you will go to first for a CVE assignment. MITRE, the organization that manages CVE administration, is also a ["CNA of Last Resort" for open source projects](https://cveform.mitre.org/) and can be used if no better scope is available.
 
 
 ### Create an embargo list
@@ -279,7 +287,7 @@ See [`Runbook.md`]( https://github.com/ossf/oss-vulnerability-guide/blob/main/ru
 
 7. **Cut a release and publicly disclose the issue**
 
-	On the day of public disclosure, publish your disclosure announcement ([see templates](#communication-templates)). If using GitHub Security Advisories, "publishing" your private Security Advisory will add it to the "Security" tab. If you are not using GitHub Security Advisories, publish the announcement to your release notes or security bulletins. If you have CVE ids for the vulnerabilities fixed, include the CVE id(s) of the vulnerabilities that were fixed in this release.
+	On the day of public disclosure, publish your disclosure announcement ([see templates](#communication-templates)). If using GitHub Security Advisories, "publishing" your private Security Advisory will add it to the "Security" tab and start the process of obtaining a CVE. If you are not using GitHub Security Advisories, publish the announcement to your release notes or security bulletins. If you have CVE ids for the vulnerabilities fixed, include the CVE id(s) of the vulnerabilities that were fixed in this release.
 
 	It's also recommended to send the announcement to appropriate mailing lists for your community (i.e., a security-announce@ list and even a general mailing list for high-impact vulnerabilities).
 


### PR DESCRIPTION
Hello, I've made some minor tweaks to this guide around GitHub Security Advisories. GitHub is a CNA for open-source repositories, so I added some content there, and clarified in a couple of places as well. 

cc: @rschultheis @katecatlin @andrewbredow 