### PR TITLE
Additions: what vuln reporters want; report intake; more troubleshooting scenarios

### DIFF
--- a/guide.md
+++ b/guide.md
@@ -3,7 +3,7 @@
 **Table of Contents**
 * **[Before you begin](#before-you-begin)**
   * [About this guide](#about-this-guide)
-  * [Who's a vulnerability reporter?](#whos-a-vulnerability-reporter)
+  * [Who's a vulnerability reporter?](#whos-a-vulnerability-reporter-aka-finder)
   * [What does the vulnerability reporter want?](#what-does-the-vulnerability-reporter-want)
 * **[Set up the vulnerability management *infrastructure*](#setting-up-the-vulnerability-management-infrastructure)**
   * [Create a vulnerability management team (VMT)](#create-a-vulnerability-management-team-vmt)
@@ -78,7 +78,7 @@ It's important to be ready for a vulnerability report *before* you get a report.
 Every project has different goals, capabilities, and norms. A critical first step to addressing security vulnerabilities is to share with downstream consumers or collaborators how the project will take in vulnerability reports and what a reporter's expectations of communication and response should be. Larger, more experienced projects will possibly have a dedicated team (see VMT below) of security specialists that have experience within open source of fixing security bugs. Small-to-medium-sized projects most likely will not have access to these trained professionals, or that type of work is simply out of their scope. It is important to understand that all software will have defects; some of those defects will have security-impacting aspects (impacting data's confidentiality, integrity, availability, or auditability). A small bit of preparation at the start of a project can ensure the team talks about and documents what they will do when these types of reports arise.
 
 Processes and tooling do not need to be complex and burdensome to the maintainers and contributors, but the following should be clearly documented by the project to ensure a reporter can get the bug report to the responsible developers:
-- How to contact the team about a potential security vulnerability
+- How to contact the team about a potential security vulnerability 
 - The vulnerability report can be kept private until such time the project decides to share more broadly
 - The reporter's expectations on communication/collaboration around the issue are properly set
 
@@ -108,17 +108,19 @@ Never make this team coordination alias "security@[yourdomain]," since that is a
 
 #### Location of information on how to report vulnerabilities
 
-You'll need an easy, obvious way that vulnerability reporters can use to alert issues to your VMT, and you need to *tell reporters what that is*. How can you tell people what that way is? Every project organizes itself differently. The goal here is: "make it obvious."
+You'll need an easy, obvious way that vulnerability reporters can contact your project (specifically: your project's VMT) to report security flaws that they have found in your code, and you need to *tell reporters what that is*. Typically, how to report a security vulnerability is described in a project's security policy or SECURITY.md file on GitHub, and/or on an easy-to-find page on the project's website. The goal here is: "make it obvious."
+
+In this section, we explain _where you should put the instructions_ for how vulnerability finders can contact your project to report security vulns. In the [next section](#intake-method), we explain _what mechanisms or communications methods you may wish to use to actually receive vulnerability reports_. 
 
 
 ##### If you are using GitHub
 
-[GitHub Security Advisory](https://docs.github.com/en/free-pro-team@latest/github/managing-security-vulnerabilities/about-github-security-advisories) is the feature that displays the "Security Policy" and "Security Advisory" information in the top-level security tab on a GitHub repository. To populate the "Security Policy" field, you will want to create a [`SECURITY.md`](https://github.com/ossf/oss-vulnerability-guide/tree/main/templates/security_policies) file in your root, docs, or .github folder. ([GitHub documentation: Creating a Security Policy](https://docs.github.com/en/free-pro-team@latest/github/managing-security-vulnerabilities/adding-a-security-policy-to-your-repository)) Whatever you decide, our recommendation is to also put a link to the `SECURITY.md` in your `README`. The Security tab isn't obvious to everyone; the `README` puts this information front and center. (Just putting disclosure information in the `README` will not populate the Security tab.)
+On GitHub, you can write a Security Policy that includes instructions for how you want researchers to report discovered security vulnerabilities to your project. [GitHub Security Advisory](https://docs.github.com/en/free-pro-team@latest/github/managing-security-vulnerabilities/about-github-security-advisories) is the feature that displays the "Security Policy" and "Security Advisory" information in the top-level security tab on a GitHub repository. To populate the "Security Policy" field, you will want to create a [`SECURITY.md`](https://github.com/ossf/oss-vulnerability-guide/tree/main/templates/security_policies) file in your root, docs, or .github folder. ([GitHub documentation: Creating a Security Policy](https://docs.github.com/en/free-pro-team@latest/github/managing-security-vulnerabilities/adding-a-security-policy-to-your-repository)) Whatever you decide, our recommendation is to also put a link to the `SECURITY.md` in your `README`. The Security tab isn't obvious to everyone; the `README` puts this information front and center. (Just putting disclosure information in the `README` will not populate the Security tab.)
 
 
 ##### If you are using another service
 
-We recommend that you put your security policy in the same place where you document how to report issues, with a distinct callout for "Reporting a security issue." If this page is not a top-level page, we recommend also adding a link to this documentation on a landing page, a security features page, a contact page, or other prominent, heavily-trafficked page. If you have site search, "vulnerability," "report security," and "security issue" are common keywords that you'll want to incorporate. If you have a `README.md` or `SECURITY.md` page, put it there (and if you don't, consider adding them).
+On your project's website or similar, you can write a Security Policy that includes instructions for how you want researchers to report discovered security vulnerabilities to your project, or you can simply include clear and specific contact information to "report a security vulnerability". We recommend that you put your security policy in the same place where you document how to report issues, with a distinct callout for "Reporting a security issue." If this page is not a top-level page, we recommend also adding a link to this documentation on a landing page, a security features page, a contact page, or other prominent, heavily-trafficked page. If you have site search, "vulnerability," "report security," and "security issue" are common keywords that you'll want to incorporate. If you have a `README.md` or `SECURITY.md` page, put it there (and if you don't, consider adding them).
 
 
 #### Intake Method

--- a/guide.md
+++ b/guide.md
@@ -4,6 +4,7 @@
 * **[Before you begin](#before-you-begin)**
   * [About this guide](#about-this-guide)
   * [Who's a vulnerability reporter?](#whos-a-vulnerability-reporter)
+  * [What does the vulnerability reporter want?](#what-does-the-vulnerability-reporter-want)
 * **[Set up the vulnerability management *infrastructure*](#setting-up-the-vulnerability-management-infrastructure)**
   * [Create a vulnerability management team (VMT)](#create-a-vulnerability-management-team-vmt)
   * [Set up report intake](#set-up-report-intake)
@@ -56,6 +57,16 @@ Ultimately the goal of using CVD is to reduce the risk to [Consumers](https://gi
 
 It is important to thank reporters for taking the time to find the developer and go through the project's process. One of the ways to do that is to make the project's process of issue intake is as discoverable, smooth, and low-friction as possible. Additional methods to thank reporters will be shared later in the [Response Process](#the-vulnerability-response-process)).
 
+### What does the vulnerability reporter want? 
+
+When someone finds a security vulnerability and reports it to your project, their main goal is to get you to **fix the vulnerability to help make your project more secure**. Thus, they are looking for a project maintainer or contributor to patch the vulnerability so that when users update to the most recent version of the software, they are no longer vulnerable to the software flaw that was reported. 
+
+Often, vulnerability reporters may want other ancillary things to happen. Examples of normal, reasonable things a finder may ask for include:
+* **CVE issuance**: Security flaws in specific commercial or OSS products or projects are often issued CVE numbers to refer to a specific vulnerability in a specific version of a product. CVE numbers help users of systems learn about security risks in specific versions of those systems so that they can choose to update to patched versions instead. Security researchers may seek to obtain a CVE ID for their reported vulnerability from a recognized [CNA](https://cve.mitre.org/cve/cna.html). This is normal and safe to do and will not cost you anything or harm your project. If you want, you can [learn more about the CVE program here](https://cve.mitre.org/about/faqs.html#what_is_cve) or on the [Common Vulnerabilities and Exposures wikipedia page](https://en.wikipedia.org/wiki/Common_Vulnerabilities_and_Exposures).
+* **Acknowledgment**: Giving vulnerability researchers credit for their contributions is a typical way to acknowledge the value they have offered to your project. Typically, this is included in the patch notes when an update is issued. 
+* **Ability to issue a Technical Advisory**: Sometimes security researchers will seek to publish a Technical Advisory on their (or their employer's) website on the day on which you release the patch which fixes the reported security flaw(s). A Technical Advisory serves to both improve user awareness of the security updates to encourage them to patch and mitigate risk, as well as to profile the researcher's finding. Co-issuance of Advisories on the release date of fixes for security flaws is common practice across both open-source and commercial software. A typical Technical Advisory will include a summary of the report, the impact of the vulnerability, details about the vulnerability, recommendations to the developer and/or end users, and a timeline of communication milestones between the vendor/affected project and the vulnerability reporter.
+
+Security researchers who report vulnerabilities to your project unsolicited (unless as part of an official bug bounty program that you may choose to run) will never ask you for money in exchange for details about security findings that they are reporting to you.
 
 ## Set up the vulnerability management "infrastructure"
 

--- a/guide.md
+++ b/guide.md
@@ -16,7 +16,7 @@
 * **[Apply the vulnerability response process](#apply-the-vulnerability-response-process)**
   * [Runbook](#runbook)
   * [Response process](#response-process)
-* **[Troubleshooting](#troubleshooting-the-process)**
+* **[Troubleshooting common challenges to Coordinated Vulnerability Disclosure](#troubleshooting-common-challenges-to-coordinated-vulnerability-disclosure)**
 * **[Acknowledgements](#acknowledgements)**
 
 
@@ -298,35 +298,53 @@ See [`Runbook.md`]( https://github.com/ossf/oss-vulnerability-guide/blob/main/ru
 
 	You might choose to briefly withhold details about how the vulnerability can be exploited, hoping that this will give users a little more time to update before attackers begin exploiting the vulnerability. This only makes sense if it's not obvious to attackers how the vulnerability can be exploited, and in most cases, attackers will find it obvious. In addition, attackers can usually review changes made to software (in source or executable form) and easily determine an attack. Thus, withholding detailed information can only be helpful for a few days at most, even in the few cases where it helps at all.
 
-## Troubleshooting the process
+## Troubleshooting common challenges to Coordinated Vulnerability Disclosure
 
-**Our reporter isn't very responsive**
+Sometimes, the coordinated vulnerability disclosure process does not go smoothly. In this section, we offer advice for a few potential challenges you may encounter. 
+
+**_We're not sure if this is actually a security issue_** 
+
+If you receive a vulnerability report but do not understand whether it is a security issue, you should ask domain experts in your VMT, or you can try to ask additional questions of the person who reported the vulnerability. If their report is too brief or unclear, you may wish to ask things like:
+* In which lines of code is the vulnerability located?
+* How specifically does this vulnerability create a security risk?
+* If we leave the code as it is, what could an attacker ultimately do?
+* How can we replicate the issue? / Do you have a working proof-of-concept that you would be willing to show us?
+* What would we have to do to fix the issue? (_Note: You should still do your best to validate the security of every contributed patch - regardless of its' source - to seek to prevent both accidentially insecure or intentionally malicious commits_). 
+
+Sometimes, vulnerability researchers will be willing to invest additional time to help you better understand the issue so that you can fix it. If they do this, be respectful of their time and collaborative and straightforward in your approach so that you can work together to get the vulnerability remediated. 
+
+
+**_Our reporter isn't very responsive_**
 
 After the initial report, your reporter will choose how responsive to be (that's the "coordination" part of Coordinated Vulnerability Disclosure). If you receive a report that you cannot reproduce and have tried multiple times to reach the reporter, send them a polite, final note that you were not able to reproduce the issue and will not be issuing a security advisory. Encourage them to reopen the issue if they can reproduce it in the future.
 
 
-**Patch development isn't going well**
+**_Patch development isn't going well_**
 
 If you're struggling to develop a patch that fully resolves the issue, you have a couple of options:
 
-1. **Get more help.**
-
+* **Get more help.** 
 It is okay to expand the people working on an issue beyond the VMT when you struggle to create a fix. Is there a project contributor who has particular knowledge of the affected area? Do you know someone who specializes in this security area? (e.g., networking security, container security, etc.) Do VMT members have resources at their company (e.g., vuln response teams) who can help?
 
-2. **Patch partially (break the exploitation chain).**
-
+* **Patch partially (break the exploitation chain).**
 If you've gotten more help, the embargo period is about to end, and you don't have a complete fix yet, a patch that breaks the exploitation chain before the public disclosure time is preferable to no patch. This does not mean you stop working on a complete fix after disclosure, but that you release the solution you do have. 
 In this context, "break the exploitation chain" means creating a partial fix that makes the exploit much more difficult. 
+ 	In this option, you must communicate and document that this patch does not resolve the issue entirely. Users must understand their exposure level even after patching. When you have a comprehensive fix, remember to add updates to past announcements to point users to the latest information. (For example, your release notes for the comprehensive fix could say, "Further security improvements addressing $CVEID.")
 
-In this option, you must communicate and document that this patch does not resolve the issue entirely. Users must understand their exposure level even after patching. When you have a comprehensive fix, remember to add updates to past announcements to point users to the latest information. (For example, your release notes for the comprehensive fix could say, "Further security improvements addressing $CVEID.")
-
-3. **Disclose without a patch and document it well.**
-
+* **Disclose without a patch and document it well.**
 If an issue is unresolvable, it is better that users know than not know. "Security through obscurity" is a weak defense in vulnerability management. Any existing vulnerability can be found and exploited by bad actors. Document the issue well, including any related workarounds for common environments, and continue to work on it in public.
 
-4. **Someone publicly disclosed a vulnerability without working with us**
 
-Maybe it's found in a research paper, an article, or on social media, but if someone publicly discloses a vulnerability in your project that you had no prior awareness of, the best thing to do is treat it as a regular project issue (it is, after all, already public) but assign it high priority and communicate with your users, particularly if it's a publicized or critical issue. Let them know you're aware of the issue, how it's being handled, and where they should watch for updates. Addressing an issue of this type publicly removes a significant part of the communication burden, as it allows others to find this information and not have to contact the VMT.
+**_Someone publicly disclosed a vulnerability without working with us_**
+
+Whether it is found in a research paper, a media article, a security conference preesentation, or on social media, if someone publicly discloses a vulnerability in your project that you had no prior awareness of, the best thing to do is treat it as a regular project issue (it is, after all, already public) but assign it high priority and communicate with your users, particularly if it's a publicized or critical issue. Let them know you're aware of the issue, how it's being handled, and where they should watch for updates. Addressing an issue of this type publicly removes a significant part of the communication burden, as it allows others to find this information and not have to contact the VMT.
+
+
+**_We believe the vulnerability is being actively exploited in the wild_** 
+
+Open source software is powerful, and unmitigated security flaws in OSS projects can have real-world impact on people and organizations around the world. The exploitation of security vulnerabilities in open source (and closed source!) projects can lead to the compromise of downstream dependents and both direct and indirect users of your software. Examples of these so-called "supply chain" attacks have been well-documented in recent years in mainstream media. 
+
+If you have reason to believe that a vulnerability in your code is being actively exploited by threat actors, it is important to quickly notify users and issue patches that remediate the security risks. We aim to update a future version of this guide with additional resources for OSS project maintainers facing this challenge. 
 
 
 ## Acknowledgements


### PR DESCRIPTION
- Creation of section about what vulnerability reporters want and may reasonably ask for (CVEs, acknowledgement, advisory publication) and what they won't (payment) to hopefully help set norms/expectations for (and prevent inappropriate behaviour toward) maintainers  
- (Hopefully a) clarification in the "intake" section around security policy vs the actual communication mechanism used 
- Addition of a few troubleshooting scenarios (ie: not sure if this is a vuln, this is being exploited in the wild, etc) and a few more details in this section 
- If we have resources for projects in need of immediate incident response support, it might be useful to also add in the troubleshooting part I wrote about exploitation (cc: @SecurityCRob who might have suggestions here)
- Minor formatting/wording tweaks  

Also: Let me know if these are too big for a PR and should have been opened as issues instead :) all rule-breaking is inadvertent, I promise   