### PR TITLE
Release MTW- not (say) Fridays!

### DIFF
--- a/guide.md
+++ b/guide.md
@@ -272,8 +272,11 @@ See [`Runbook.md`]( https://github.com/ossf/oss-vulnerability-guide/blob/main/ru
 
 	The advantage of getting a CVE for a vulnerability is that it provides a path to notify users of the vulnerability and to verify that the vulnerability is fixed. Many organizations specifically track CVEs, so that even if they don't see your vulnerability announcement they'll see the CVE report.
 
+6. **Decide the date of public release**
 
-6. **(If applicable) Notify providers under embargo**
+	In many countries people often have days off on Fridays, Saturdays, and/or Sundays. So if the vulnerability is not publicly known (e.g., it's not being exploited), it's often better to make the public release on Monday, Tuesday, or Wednesday. In addition, try to avoid releasing a vulnerability fix on a widely-observed holiday. This gives people some time to do the update during their workday.
+
+7. **(If applicable) Notify providers under embargo**
 
 	Embargo notifications are sent anywhere from 1-30 work days before the intended date of public disclosure. This timeframe depends on the severity and exploitability of the issue, the complexity of the patch, and the type of providers your project is used by (can the providers feasibly qualify and patch in 5 days? 10 days?). Also consider holidays and significant events that could impact the provider’s ability to prepare and adjust your dates accordingly (e.g., if your project is heavily used by retailers, don’t expect them to be able to prepare over the [US Black Friday shopping days](https://en.wikipedia.org/wiki/Black_Friday_(shopping))).
 
@@ -281,7 +284,7 @@ See [`Runbook.md`]( https://github.com/ossf/oss-vulnerability-guide/blob/main/ru
 
 
 
-7. **Cut a release and publicly disclose the issue**
+8. **Cut a release and publicly disclose the issue**
 
 	On the day of public disclosure, publish your disclosure announcement ([see templates](#communication-templates)). If using GitHub Security Advisories, “publishing” your private Security Advisory will add it to the “Security” tab. If you are not using GitHub Security Advisories, publish the announcement to your release notes and/or security bulletins. If you have CVE ids for the vulnerabilities fixed, include the CVE id(s) of the vulnerabilities that were fixed in this release.
 


### PR DESCRIPTION
The log4j fix was released on a Friday, which created
a lot of problems for overworked admins over the weekend.
Maybe that was unavoidable, but it makes it clear that the
day of week of a release matters.

It turns out that worldwide, the weekend (non-working week)
is typically Friday, Saturday, and/or Sunday:
https://en.wikipedia.org/wiki/Workweek_and_weekend

Let's recommend security releases occur MWF, and explain why.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>