### PR TITLE
Recommend using GitHub private reporting

### DIFF
--- a/maintainer-guide.md
+++ b/maintainer-guide.md
@@ -126,7 +126,7 @@ The vulnerability reporter is doing you a favor; don't add more steps than absol
 
 ##### If you are using GitHub
 
-If your project is on GitHub, we recommend [enabling privately reporting a security vulnerability](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability),even though that feature is currently only in beta. This is an easy-to-use mechanism, and ease of use is key.
+If your project is on GitHub, we recommend [enabling privately reporting a security vulnerability](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability), even though that feature is currently only in beta. This is an easy-to-use mechanism, and ease of use is key.
 
 We recommend that you also follow the directions for [another service](#if-you-are-using-another-service). In particular, include email address(es) people can use for reporting instead of the GitHub private reporting mechanism.
 

--- a/maintainer-guide.md
+++ b/maintainer-guide.md
@@ -126,13 +126,11 @@ The vulnerability reporter is doing you a favor; don't add more steps than absol
 
 ##### If you are using GitHub
 
-You may choose to use GitHub Security Advisory, but it _cannot_ today be used as a general-purpose intake method for vulnerability reports.
-GitHub Security Advisory is a GitHub feature that allows _only_ selected users to privately share information about reported issues, develop patches on a private branch, and publish a security advisory.
-The GitHub Security Advisory workflow starts when a repo or org admin opens a Security Advisory.
-General users cannot create a Security Advisory or create a private "security issue" out of a standard GitHub issue.
-Thus, currently GitHub Security Advisory _must_ be supplemented with other intake mechanisms.
+If your project is on GitHub, we recommend [enabling privately reporting a security vulnerability](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability),even though that feature is currently only in beta. This is an easy-to-use mechanism, and ease of use is key.
 
-If you choose not to use GitHub Security Advisory features for private patch development, follow the directions for [another service](#if-you-are-using-another-service).
+We recommend that you also follow the directions for [another service](#if-you-are-using-another-service). In particular, include email address(es) people can use for reporting instead of the GitHub private reporting mechanism.
+
+You may choose to use GitHub Security Advisory without enabling private reporting, but if you don't enable private reporting, only selected users can report vulnerabilities.
 
 If you choose to use GitHub Security Advisory for private patch development, here's how we recommend supplementing it.
 Your Security Policy should instruct reporters to email the VMT with a vulnerability report ([see `SECURITY.md` templates](https://github.com/ossf/oss-vulnerability-guide/tree/main/templates/security_policies)). The VMT will then open a Security Advisory and add the reporter as a collaborator ([see GitHub documentation on GitHub Security Advisory](https://docs.github.com/en/free-pro-team@latest/github/managing-security-vulnerabilities/about-github-security-advisories)). It is also appropriate to email that alias for questions about the vulnerability disclosure process.


### PR DESCRIPTION
Recommend that people use GitHub private reporting. Yes, it's technically only in "beta", but it is *easy* to use by many, and that's a key advantage of it.